### PR TITLE
docs: add Podman rootless UID/GID mapping troubleshooting

### DIFF
--- a/PODMAN.md
+++ b/PODMAN.md
@@ -149,7 +149,6 @@ cat /etc/subgid | grep YOUR_USERNAME
 
 2. **Reset Podman** to apply changes:
 ```bash
-podman system reset
 podman system migrate
 ```
 


### PR DESCRIPTION
## Summary
- Add troubleshooting section for Podman rootless mode UID/GID mapping errors
- Documents fix for missing subuid/subgid ranges configuration
- Resolves build failures on machines without proper user namespace setup

## Context
Alpine-based multi-stage builds fail on rootless Podman when the user lacks subuid/subgid ranges configured in `/etc/subuid` and `/etc/subgid`. This is a common setup issue encountered when running Podman in rootless mode.

## Test plan
- [x] Instructions tested against error message from affected machine
- [x] User confirms fix resolves build issue on their machine

## Files changed
- `PODMAN.md`: Added new "Rootless Podman: UID/GID Mapping Errors" troubleshooting section with step-by-step fix instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a troubleshooting section to PODMAN.md for rootless Podman UID/GID mapping errors. It explains how to configure subuid/subgid ranges and reset/migrate Podman to fix Alpine-based multi-stage build failures.

<sup>Written for commit c5bfdabfbe5d2967fb1c43f22a5d823e73c4e2ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

