### PR TITLE
fix(config): apply reload immediately and add server fetch error logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,13 +182,11 @@ type Server struct {
 // ConfigManager provides thread-safe access to configuration with dynamic reload
 // Uses atomic.Value for lock-free reads (critical for performance during server polling)
 // Uses sync.RWMutex to serialize reload operations (rare writes vs frequent reads)
-// Debounces rapid file writes to prevent excessive reload attempts during editor save operations
 type ConfigManager struct {
-	config        atomic.Value // stores *Config
-	configPath    string
-	lastModTime   time.Time
-	mu            sync.RWMutex
-	debounceTimer *time.Timer // Timer for debouncing rapid file writes
+	config      atomic.Value // stores *Config
+	configPath  string
+	lastModTime time.Time
+	mu          sync.RWMutex
 }
 
 // NewConfigManager creates a new ConfigManager with an initial configuration
@@ -227,59 +225,44 @@ func (cm *ConfigManager) getLastModTime() (time.Time, error) {
 	return info.ModTime(), nil
 }
 
-// checkAndReloadIfNeeded checks if the config file has changed and schedules debounced reload
-// Returns nil immediately after scheduling (doesn't wait for reload to complete)
-// Debouncing prevents excessive reloads during rapid file writes (e.g., editor save operations)
-// Most text editors perform multiple write operations when saving files, causing multiple
-// file modification events. Without debouncing, each write would trigger a separate reload.
+// checkAndReloadIfNeeded checks if the config file has changed and reloads synchronously.
+// Uses a short 5ms debounce to batch rapid file writes (e.g., editor saves).
+// Returns after reload completes (or immediately if no change detected).
 func (cm *ConfigManager) checkAndReloadIfNeeded() error {
 	cm.mu.Lock()
-	defer cm.mu.Unlock()
 
 	// Check current file modification time
 	currentModTime, err := cm.getLastModTime()
 	if err != nil {
+		cm.mu.Unlock()
 		return fmt.Errorf("failed to stat config file: %w", err)
 	}
 
 	// No change detected
 	if currentModTime.Equal(cm.lastModTime) || currentModTime.Before(cm.lastModTime) {
+		cm.mu.Unlock()
 		return nil
 	}
 
-	// File has changed, schedule debounced reload
-	// Stop any existing timer to reset debounce window on each new write
-	if cm.debounceTimer != nil {
-		cm.debounceTimer.Stop()
-	}
+	// File has changed, release lock during debounce wait
+	cm.mu.Unlock()
 
-	// Create new timer that fires 100ms after last write
-	// If another write occurs within 100ms, this timer will be stopped and reset
-	cm.debounceTimer = time.AfterFunc(100*time.Millisecond, func() {
-		// Timer callback runs in separate goroutine
-		if err := cm.performReload(); err != nil {
-			log.Printf("Config reload failed: %v", err)
-		}
-	})
+	// Short debounce: wait 5ms for additional writes to settle
+	// This prevents excessive reloads during editor save operations
+	time.Sleep(5 * time.Millisecond)
 
-	return nil
-}
-
-// performReload executes the actual config reload (load, validate, atomic swap)
-// Called by debounce timer after writes have settled
-// Logs errors but never crashes - bot continues with old config on reload failure
-func (cm *ConfigManager) performReload() error {
+	// Re-acquire lock for reload
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// Double-check modification time (file might have changed again during debounce)
-	currentModTime, err := cm.getLastModTime()
+	// Re-check file modification time after debounce
+	currentModTime, err = cm.getLastModTime()
 	if err != nil {
 		return fmt.Errorf("failed to stat config file: %w", err)
 	}
 
-	// If file hasn't changed since last reload, skip
-	if currentModTime.Equal(cm.lastModTime) {
+	// If no change detected after debounce (file was written before our check), skip
+	if currentModTime.Equal(cm.lastModTime) || currentModTime.Before(cm.lastModTime) {
 		return nil
 	}
 
@@ -297,7 +280,6 @@ func (cm *ConfigManager) performReload() error {
 	}
 
 	// Initialize server IPs from global ServerIP setting.
-	// Must complete before atomic swap; readers see config via atomic.Value without locks.
 	initializeServerIPs(newCfg)
 
 	// Success: atomically swap config and update mod time
@@ -308,18 +290,11 @@ func (cm *ConfigManager) performReload() error {
 	return nil
 }
 
-// Cleanup stops the debounce timer and releases resources
-// Called during bot shutdown to prevent timer callbacks after shutdown
+// Cleanup releases resources
+// Called during bot shutdown
 // Safe to call multiple times (idempotent)
 func (cm *ConfigManager) Cleanup() {
-	cm.mu.Lock()
-	defer cm.mu.Unlock()
-
-	// Stop timer if running
-	if cm.debounceTimer != nil {
-		cm.debounceTimer.Stop()
-		cm.debounceTimer = nil
-	}
+	// No-op: no resources to clean up anymore
 }
 
 // WriteConfig writes a complete new configuration to disk with backup and atomic write
@@ -990,16 +965,19 @@ func fetchServerInfo(server Server) ServerInfo {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
+		log.Printf("Server '%s' failed to create request: %v", server.Name, err)
 		return offlineServerInfo(server)
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		log.Printf("Server '%s' (%s) request failed: %v", server.Name, url, err)
 		return offlineServerInfo(server)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		log.Printf("Server '%s' (%s) returned status %d", server.Name, url, resp.StatusCode)
 		return offlineServerInfo(server)
 	}
 
@@ -1010,6 +988,7 @@ func fetchServerInfo(server Server) ServerInfo {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		log.Printf("Server '%s' (%s) failed to decode response: %v", server.Name, url, err)
 		return offlineServerInfo(server)
 	}
 
@@ -1017,6 +996,8 @@ func fetchServerInfo(server Server) ServerInfo {
 	if trackName == "." || trackName == "" {
 		trackName = "Unknown"
 	}
+
+	log.Printf("Server '%s' online: %s, players %d/%d", server.Name, trackName, data.Clients, data.MaxClients)
 
 	return ServerInfo{
 		Name:       server.Name,

--- a/main_test.go
+++ b/main_test.go
@@ -654,25 +654,17 @@ func TestCheckAndReloadIfNeeded_ValidReload(t *testing.T) {
 	data, _ = json.Marshal(newConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Trigger reload (schedules debounce)
+	// Trigger reload (synchronous with 5ms debounce)
 	err := cm.checkAndReloadIfNeeded()
 
 	if err != nil {
-		t.Fatalf("Expected successful reload scheduling, got error: %v", err)
+		t.Fatalf("Expected successful reload, got error: %v", err)
 	}
 
-	// Config should NOT be updated immediately (debounce pending)
-	if cm.GetConfig().ServerIP == "10.0.0.1" {
-		t.Error("Config should not be updated immediately after scheduling")
-	}
-
-	// Wait for debounce timer to fire
-	time.Sleep(150 * time.Millisecond)
-
-	// Config should be updated after debounce
+	// Config should be updated immediately after function returns (after 5ms debounce)
 	currentCfg := cm.GetConfig()
 	if currentCfg.ServerIP != "10.0.0.1" {
-		t.Errorf("Expected ServerIP '10.0.0.1' after debounce, got '%s'", currentCfg.ServerIP)
+		t.Errorf("Expected ServerIP '10.0.0.1' after reload, got '%s'", currentCfg.ServerIP)
 	}
 }
 
@@ -703,32 +695,18 @@ func TestCheckAndReloadIfNeeded_InvalidJSON(t *testing.T) {
 	// Store original config for comparison
 	originalIP := cm.GetConfig().ServerIP
 
-	// Trigger reload (schedules debounce)
-	// Note: checkAndReloadIfNeeded will return nil immediately (debounce scheduled)
-	// The error will occur in the background during performReload
+	// Trigger reload (synchronous with 5ms debounce)
+	// Error is returned immediately if reload fails
 	err := cm.checkAndReloadIfNeeded()
 
-	// With debouncing, the check returns immediately (error happens in background)
-	if err != nil {
-		t.Fatalf("Expected nil during scheduling, got: %v", err)
+	// Should get an error for invalid JSON
+	if err == nil {
+		t.Fatal("Expected error for invalid JSON, got nil")
 	}
 
-	// Config should remain unchanged immediately
+	// Config should remain unchanged after failed reload
 	if cm.GetConfig().ServerIP != originalIP {
-		t.Errorf("Config should not change immediately, got ServerIP: %s", cm.GetConfig().ServerIP)
-	}
-
-	// Wait for debounce timer to fire and reload to fail
-	time.Sleep(150 * time.Millisecond)
-
-	// Config should remain unchanged (reload failed)
-	currentCfg := cm.GetConfig()
-	if currentCfg == nil {
-		t.Fatal("Config should not be nil after failed reload")
-	}
-
-	if currentCfg.ServerIP != originalIP {
-		t.Errorf("Config should remain unchanged on invalid JSON, got ServerIP: %s", currentCfg.ServerIP)
+		t.Errorf("Config should remain unchanged on invalid JSON, got ServerIP: %s", cm.GetConfig().ServerIP)
 	}
 }
 
@@ -768,25 +746,18 @@ func TestCheckAndReloadIfNeeded_ValidationFailure(t *testing.T) {
 	// Store original config for comparison
 	originalIP := cm.GetConfig().ServerIP
 
-	// Trigger reload (schedules debounce)
+	// Trigger reload (synchronous with 5ms debounce)
+	// Error is returned immediately if reload fails
 	err := cm.checkAndReloadIfNeeded()
 
-	// With debouncing, returns immediately (error happens in background)
-	if err != nil {
-		t.Fatalf("Expected nil during scheduling, got: %v", err)
+	// Should get an error for validation failure
+	if err == nil {
+		t.Fatal("Expected error for validation failure, got nil")
 	}
 
-	// Wait for debounce timer to fire and reload to fail
-	time.Sleep(150 * time.Millisecond)
-
-	// Config should remain unchanged (reload failed)
-	currentCfg := cm.GetConfig()
-	if currentCfg == nil {
-		t.Fatal("Config should not be nil after failed reload")
-	}
-
-	if currentCfg.ServerIP != originalIP {
-		t.Errorf("Config should remain unchanged on validation failure, got ServerIP: %s", currentCfg.ServerIP)
+	// Config should remain unchanged after failed reload
+	if cm.GetConfig().ServerIP != originalIP {
+		t.Errorf("Config should remain unchanged on validation failure, got ServerIP: %s", cm.GetConfig().ServerIP)
 	}
 }
 
@@ -1232,9 +1203,6 @@ func TestIntegration_ConfigReloadWithBot(t *testing.T) {
 
 	cm := NewConfigManager(configPath, initialConfig)
 
-	// Simulate bot update cycle checking for config changes
-	initialIP := cm.GetConfig().ServerIP
-
 	// Wait to ensure different modification time
 	time.Sleep(10 * time.Millisecond)
 
@@ -1250,26 +1218,14 @@ func TestIntegration_ConfigReloadWithBot(t *testing.T) {
 	data, _ = json.Marshal(newConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Simulate bot checking for config updates (schedules debounce)
+	// Simulate bot checking for config updates (synchronous with 5ms debounce)
 	err := cm.checkAndReloadIfNeeded()
 	if err != nil {
 		t.Fatalf("checkAndReloadIfNeeded failed: %v", err)
 	}
 
-	// Config should not change immediately (debounce pending)
-	if cm.GetConfig().ServerIP != initialIP {
-		t.Error("Config should not change immediately after scheduling")
-	}
-
-	// Wait for debounce timer to fire
-	time.Sleep(150 * time.Millisecond)
-
-	// Verify config was reloaded after debounce
+	// Config should be updated immediately after function returns
 	currentCfg := cm.GetConfig()
-	if currentCfg.ServerIP == initialIP {
-		t.Error("Config was not reloaded after debounce, ServerIP unchanged")
-	}
-
 	if currentCfg.ServerIP != "10.0.0.1" {
 		t.Errorf("Expected ServerIP '10.0.0.1' after reload, got '%s'", currentCfg.ServerIP)
 	}
@@ -1309,18 +1265,15 @@ func TestIntegration_InvalidConfigDuringRuntime(t *testing.T) {
 	data, _ = json.Marshal(invalidConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Attempt reload (schedules debounce)
+	// Attempt reload (synchronous with 5ms debounce)
 	err := cm.checkAndReloadIfNeeded()
 
-	// With debouncing, returns immediately (error happens in background)
-	if err != nil {
-		t.Fatalf("Expected nil during scheduling, got: %v", err)
+	// Should get an error for invalid config
+	if err == nil {
+		t.Fatal("Expected error for invalid config, got nil")
 	}
 
-	// Wait for debounce timer to fire and reload to fail
-	time.Sleep(150 * time.Millisecond)
-
-	// Config should remain unchanged (reload failed)
+	// Config should remain unchanged after failed reload
 	currentCfg := cm.GetConfig()
 	if currentCfg == nil {
 		t.Fatal("Config should not be nil after failed reload")
@@ -1513,23 +1466,15 @@ func TestConfigManager_DebounceSingleWrite(t *testing.T) {
 	data, _ = json.Marshal(newConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Trigger reload check (schedules debounce)
+	// Trigger reload check (synchronous with 5ms debounce)
 	err := cm.checkAndReloadIfNeeded()
 	if err != nil {
 		t.Fatalf("checkAndReloadIfNeeded failed: %v", err)
 	}
 
-	// Config should NOT be updated immediately (debounce pending)
-	if cm.GetConfig().ServerIP == "10.0.0.1" {
-		t.Error("Config should not be updated immediately after scheduling")
-	}
-
-	// Wait for debounce timer to fire
-	time.Sleep(150 * time.Millisecond)
-
-	// Now config should be updated
+	// Config should be updated immediately after function returns
 	if cm.GetConfig().ServerIP != "10.0.0.1" {
-		t.Errorf("Expected ServerIP '10.0.0.1' after debounce, got '%s'", cm.GetConfig().ServerIP)
+		t.Errorf("Expected ServerIP '10.0.0.1' after reload, got '%s'", cm.GetConfig().ServerIP)
 	}
 }
 
@@ -1575,136 +1520,18 @@ func TestConfigManager_DebounceRapidWrites(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Wait for debounce timer to fire
-	time.Sleep(150 * time.Millisecond)
-
 	// Config should reflect the LAST write (10.0.0.5)
-	// Only ONE reload should have occurred
 	if cm.GetConfig().ServerIP != "10.0.0.5" {
 		t.Errorf("Expected ServerIP '10.0.0.5' after rapid writes, got '%s'", cm.GetConfig().ServerIP)
 	}
 }
 
 // TestConfigManager_DebounceTimerReset tests that timer is reset on subsequent writes
-func TestConfigManager_DebounceTimerReset(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.json")
+// TestConfigManager_DebounceTimerReset removed - async timer behavior no longer exists
+// The new synchronous 5ms debounce doesn't have timer reset behavior
 
-	initialConfig := &Config{
-		ServerIP:       "192.168.1.1",
-		UpdateInterval: 30,
-		CategoryOrder:  []string{"Drift"},
-		CategoryEmojis: map[string]string{"Drift": "🟣"},
-		Servers:        []Server{{Name: "Test", Port: 8081, Category: "Drift"}},
-	}
-
-	data, _ := json.Marshal(initialConfig)
-	os.WriteFile(configPath, data, 0644)
-
-	cm := NewConfigManager(configPath, initialConfig)
-
-	// Wait to ensure different modification time
-	time.Sleep(10 * time.Millisecond)
-
-	// First write
-	newConfig := &Config{
-		ServerIP:       "10.0.0.1",
-		UpdateInterval: 30,
-		CategoryOrder:  []string{"Drift"},
-		CategoryEmojis: map[string]string{"Drift": "🟣"},
-		Servers:        []Server{{Name: "Test", Port: 8081, Category: "Drift"}},
-	}
-
-	data, _ = json.Marshal(newConfig)
-	os.WriteFile(configPath, data, 0644)
-	cm.checkAndReloadIfNeeded()
-
-	// Wait 50ms (less than debounce delay)
-	time.Sleep(50 * time.Millisecond)
-
-	// Config should NOT be reloaded yet
-	if cm.GetConfig().ServerIP == "10.0.0.1" {
-		t.Error("Config should not be reloaded before debounce timer fires")
-	}
-
-	// Second write before first timer fires (resets timer)
-	newConfig.ServerIP = "10.0.0.2"
-	data, _ = json.Marshal(newConfig)
-	os.WriteFile(configPath, data, 0644)
-	cm.checkAndReloadIfNeeded()
-
-	// Wait another 50ms (still less than debounce delay from reset)
-	time.Sleep(50 * time.Millisecond)
-
-	// Config should STILL not be reloaded (timer was reset)
-	if cm.GetConfig().ServerIP == "10.0.0.2" {
-		t.Error("Config should not be reloaded before reset debounce timer fires")
-	}
-
-	// Wait for debounce timer to fire
-	time.Sleep(100 * time.Millisecond)
-
-	// Now config should be updated with LAST write
-	if cm.GetConfig().ServerIP != "10.0.0.2" {
-		t.Errorf("Expected ServerIP '10.0.0.2' after debounce reset, got '%s'", cm.GetConfig().ServerIP)
-	}
-}
-
-// TestConfigManager_CleanupStopsTimer tests that Cleanup stops debounce timer
-func TestConfigManager_CleanupStopsTimer(t *testing.T) {
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.json")
-
-	initialConfig := &Config{
-		ServerIP:       "192.168.1.1",
-		UpdateInterval: 30,
-		CategoryOrder:  []string{"Drift"},
-		CategoryEmojis: map[string]string{"Drift": "🟣"},
-		Servers:        []Server{{Name: "Test", Port: 8081, Category: "Drift"}},
-	}
-
-	data, _ := json.Marshal(initialConfig)
-	os.WriteFile(configPath, data, 0644)
-
-	cm := NewConfigManager(configPath, initialConfig)
-
-	// Wait to ensure different modification time
-	time.Sleep(10 * time.Millisecond)
-
-	// Write new config
-	newConfig := &Config{
-		ServerIP:       "10.0.0.1",
-		UpdateInterval: 30,
-		CategoryOrder:  []string{"Drift"},
-		CategoryEmojis: map[string]string{"Drift": "🟣"},
-		Servers:        []Server{{Name: "Test", Port: 8081, Category: "Drift"}},
-	}
-
-	data, _ = json.Marshal(newConfig)
-	os.WriteFile(configPath, data, 0644)
-
-	// Trigger reload check (schedules debounce)
-	cm.checkAndReloadIfNeeded()
-
-	// Immediately cleanup (should stop timer)
-	cm.Cleanup()
-
-	// Wait longer than debounce delay
-	time.Sleep(150 * time.Millisecond)
-
-	// Config should NOT be updated (timer was stopped)
-	if cm.GetConfig().ServerIP == "10.0.0.1" {
-		t.Error("Config should not be reloaded after Cleanup stops timer")
-	}
-
-	// Cleanup should be idempotent (calling multiple times is safe)
-	cm.Cleanup()
-	cm.Cleanup()
-
-	if cm.GetConfig().ServerIP != "192.168.1.1" {
-		t.Errorf("Config should remain unchanged after Cleanup, got ServerIP: %s", cm.GetConfig().ServerIP)
-	}
-}
+// TestConfigManager_CleanupStopsTimer removed - no timer to stop anymore
+// Cleanup is now a no-op since there's no async timer
 
 // TestConfigManager_CleanupConcurrentWithReload tests Cleanup during pending reload
 func TestConfigManager_CleanupConcurrentWithReload(t *testing.T) {
@@ -1802,14 +1629,12 @@ func TestConfigManager_DebounceWithInvalidConfig(t *testing.T) {
 	data, _ = json.Marshal(invalidConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Trigger reload check (schedules debounce)
+	// Trigger reload check (synchronous with 5ms debounce)
+	// Error is returned immediately for invalid config
 	err := cm.checkAndReloadIfNeeded()
-	if err != nil {
-		t.Fatalf("checkAndReloadIfNeeded failed: %v", err)
+	if err == nil {
+		t.Fatal("Expected error for invalid config, got nil")
 	}
-
-	// Wait for debounce timer to fire and reload to fail
-	time.Sleep(150 * time.Millisecond)
 
 	// Config should remain unchanged (reload failed)
 	if cm.GetConfig().ServerIP != originalIP {
@@ -2090,14 +1915,12 @@ func TestConfigReload_InvalidConfigPreservesIPs(t *testing.T) {
 	data, _ = json.Marshal(invalidConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Trigger reload (schedules debounce)
+	// Trigger reload (synchronous with 5ms debounce)
+	// Error is returned immediately for invalid config
 	err := cm.checkAndReloadIfNeeded()
-	if err != nil {
-		t.Fatalf("checkAndReloadIfNeeded failed: %v", err)
+	if err == nil {
+		t.Fatal("Expected error for invalid config, got nil")
 	}
-
-	// Wait for debounce and reload attempt
-	time.Sleep(150 * time.Millisecond)
 
 	// Config should remain unchanged with original IPs intact
 	cfg := cm.GetConfig()


### PR DESCRIPTION
## Summary
- Add error logging to `fetchServerInfo` for all failure paths to diagnose why servers show as offline
- Change config reload from asynchronous 100ms debounce to synchronous 5ms debounce, preventing extra update cycle delay before changes take effect

## Changes
- **Server fetch error logging**: Added logs for timeout, connection errors, non-200 status codes, and JSON decode failures in `fetchServerInfo()`
- **Synchronous config reload**: Changed `checkAndReloadIfNeeded()` to use 5ms synchronous debounce instead of 100ms async timer
- **Removed async timer**: Cleaned up `debounceTimer` field and `performReload()` function
- **Updated tests**: Tests now expect immediate config changes instead of delayed async behavior

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] Config changes now apply in same update cycle instead of requiring extra cycle
- [x] Server fetch failures now log diagnostic errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply config reloads immediately with a 5ms synchronous debounce, removing the extra update cycle. Add detailed error logging to server fetches to diagnose “offline” states.

- **Bug Fixes**
  - Config reload is now synchronous with a 5ms debounce, so changes take effect in the same update cycle.
  - Added logs for request creation failures, timeouts/connection errors, non-200 responses, JSON decode errors, and successful online status in fetchServerInfo.

- **Refactors**
  - Removed debounce timer and performReload; Cleanup is now a no-op.
  - Updated tests to expect immediate reload behavior and removed timer-specific tests.

<sup>Written for commit 3851c367d5a39b4ff0f4f69af5c4653d7ca4090e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

