### PR TITLE
refactor(config): simplify default path to /data/config.json only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Discord bot for monitoring Assetto Corsa racing servers with dynamic configurati
 | File | What | When to read |
 | ---- | ---- | ------------ |
 | `README.md` | Complete documentation: architecture, deployment, migration guide, troubleshooting, operational procedures, REST API usage | Understanding how the bot works, deploying, debugging issues, learning config reload design |
-| `main.go` | Monolithic bot implementation: types, config loading (with dynamic reload, no-config-at-startup support), server fetching, Discord integration, optional REST API server, update loop | Understanding architecture, modifying behavior, adding features, debugging no-config startup |
+| `main.go` | Monolithic bot implementation: types, config loading (single default path /data/config.json, dynamic reload, no-config-at-startup support), server fetching, Discord integration, optional REST API server, update loop | Understanding architecture, modifying behavior, adding features, debugging config path or no-config startup |
 | `main_test.go` | Unit tests for config validation, ConfigManager, and reload behavior | Verifying changes, adding tests, debugging reload logic |
 | `config.json.example` | Template for server configuration | Setting up new deployment, understanding config schema |
 | `Containerfile` | Container image definition with Go static binary | Building containers, deployment, understanding runtime |
@@ -35,6 +35,7 @@ Discord bot for monitoring Assetto Corsa racing servers with dynamic configurati
 | `pkg/proxy/` | Reverse proxy for browser-based API access via HTTP Basic Auth | Understanding proxy architecture, modifying auth/forwarding behavior |
 | `plans/` | Working planning documents for executed features | Understanding implementation history, decision rationale for past changes |
 | `plans/no-config-at-startup.md` | Planning document for no-config-at-startup feature: graceful handling of missing config at startup, nil config support in ConfigManager, container deployment patterns | Understanding why bot starts without config, nil config handling invariants, container deployment decisions |
+| `plans/data-config-json.md` | Planning document for config path simplification: single default path /data/config.json, removed ./config.json fallback | Understanding container-first config path design, getConfigPath/loadConfig synchronization |
 
 ## Build
 
@@ -73,7 +74,7 @@ export API_TRUSTED_PROXY_IPS=""
 
 **Running locally:**
 ```bash
-go run main.go                           # Uses ./config.json
+go run main.go                           # Uses /data/config.json (container default)
 go run main.go -c /path/to/config.json   # Uses specified config
 ```
 

--- a/main.go
+++ b/main.go
@@ -793,97 +793,39 @@ type Config struct {
 	Servers        []Server          `json:"servers"`
 }
 
-// loadConfig reads and parses config.json with fallback logic
+// loadConfig reads and parses config.json
 func loadConfig(providedPath string) (*Config, error) {
-	// If explicitly provided, only try that path
-	if providedPath != "" {
-		log.Printf("Loading config from provided path: %s", providedPath)
-		data, err := os.ReadFile(providedPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				log.Printf("Config file not found at %s, starting without config", providedPath)
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to read config from %s: %w", providedPath, err)
-		}
-
-		var cfg Config
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse config from %s: %w", providedPath, err)
-		}
-
-		log.Printf("Successfully loaded config from: %s", providedPath)
-		return &cfg, nil
+	// Determine the config path to use
+	configPath := providedPath
+	if configPath == "" {
+		configPath = "/data/config.json"
 	}
 
-	// Otherwise, try default locations in priority order
-	wd, err := os.Getwd()
+	log.Printf("Loading config from: %s", configPath)
+	data, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	defaultPaths := []string{
-		"/data/config.json",
-		filepath.Join(wd, "config.json"),
-	}
-
-	var errors []string
-	for _, path := range defaultPaths {
-		log.Printf("Attempting to load config from: %s", path)
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("  %s: %v", path, err))
-			continue
+		if os.IsNotExist(err) {
+			log.Printf("Config file not found at %s, starting without config", configPath)
+			return nil, nil
 		}
-
-		var cfg Config
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse config from %s: %w", path, err)
-		}
-
-		log.Printf("Successfully loaded config from: %s", path)
-		return &cfg, nil
+		return nil, fmt.Errorf("failed to read config from %s: %w", configPath, err)
 	}
 
-	// No config file found in any default location
-	log.Printf("Config file not found at any default location. Starting without config.")
-	log.Printf("Searched locations: /data/config.json, ./config.json")
-	log.Printf("Waiting for config to be created or provided via API...")
-	return nil, nil
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config from %s: %w", configPath, err)
+	}
+
+	log.Printf("Successfully loaded config from: %s", configPath)
+	return &cfg, nil
 }
 
-// getConfigPath determines the actual config file path that loadConfig uses
-// Matches loadConfig's fallback logic exactly: provided path -> /data/config.json -> ./config.json
+// getConfigPath determines the config file path that loadConfig uses
 func getConfigPath(providedPath string) string {
-	// If explicitly provided, return that path (matches loadConfig's provided-path mode)
 	if providedPath != "" {
 		return providedPath
 	}
-
-	// Otherwise, try default locations in same priority order as loadConfig's fallback mode
-	wd, err := os.Getwd()
-	if err != nil {
-		// If we can't get working directory, config load fails
-		// Return empty string to signal error condition
-		return ""
-	}
-
-	defaultPaths := []string{
-		"/data/config.json",
-		filepath.Join(wd, "config.json"),
-	}
-
-	// Return first existing path (matches loadConfig's fallback priority order)
-	for _, path := range defaultPaths {
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-	}
-
-	// No config file found - this matches loadConfig's error return when all paths fail
-	// Empty string signals that no valid config path exists
-	return ""
+	return "/data/config.json"
 }
 
 // validateConfigStruct performs fail-fast validation on loaded config

--- a/main_test.go
+++ b/main_test.go
@@ -274,15 +274,10 @@ func TestLoadConfig_ValidConfig(t *testing.T) {
 	data, _ := json.Marshal(validConfig)
 	os.WriteFile(configPath, data, 0644)
 
-	// Change to temp directory
-	origWd, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origWd)
-
-	// Test loading
-	cfg, err := loadConfig("")
+	// Test loading with explicit path
+	cfg, err := loadConfig(configPath)
 	if err != nil {
-		t.Fatalf("loadConfig(\"\") failed: %v", err)
+		t.Fatalf("loadConfig(%s) failed: %v", configPath, err)
 	}
 
 	if cfg.ServerIP != "192.168.1.1" {
@@ -300,12 +295,7 @@ func TestLoadConfig_ValidConfig(t *testing.T) {
 
 // TestLoadConfig_FileNotFound tests missing config file returns nil without error
 func TestLoadConfig_FileNotFound(t *testing.T) {
-	tmpDir := t.TempDir()
-	origWd, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origWd)
-
-	cfg, err := loadConfig("")
+	cfg, err := loadConfig("/nonexistent/path/config.json")
 	if err != nil {
 		t.Fatalf("Expected nil error for missing config file, got: %v", err)
 	}
@@ -322,11 +312,7 @@ func TestLoadConfig_InvalidJSON(t *testing.T) {
 	// Write invalid JSON
 	os.WriteFile(configPath, []byte("{invalid json}"), 0644)
 
-	origWd, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origWd)
-
-	_, err := loadConfig("")
+	_, err := loadConfig(configPath)
 	if err == nil {
 		t.Fatal("Expected error for invalid JSON, got nil")
 	}
@@ -1085,13 +1071,11 @@ func TestGetConfigPath(t *testing.T) {
 	testCases := []struct {
 		name         string
 		providedPath string
-		setupFunc    func(t *testing.T) func()
 		validateFunc func(t *testing.T, result string)
 	}{
 		{
 			name:         "explicit path is returned",
 			providedPath: "/custom/config.json",
-			setupFunc:    func(t *testing.T) func() { return func() {} },
 			validateFunc: func(t *testing.T, result string) {
 				if result != "/custom/config.json" {
 					t.Errorf("Expected path '/custom/config.json', got: %s", result)
@@ -1099,42 +1083,11 @@ func TestGetConfigPath(t *testing.T) {
 			},
 		},
 		{
-			name:         "uses ./config.json when /data/config.json doesn't exist",
+			name:         "empty path returns /data/config.json",
 			providedPath: "",
-			setupFunc: func(t *testing.T) func() {
-				tmpDir := t.TempDir()
-				configPath := filepath.Join(tmpDir, "config.json")
-				os.WriteFile(configPath, []byte("{}"), 0644)
-
-				origWd, _ := os.Getwd()
-				os.Chdir(tmpDir)
-
-				return func() {
-					os.Chdir(origWd)
-				}
-			},
 			validateFunc: func(t *testing.T, result string) {
-				// Should return the working directory config.json
-				if !strings.Contains(result, "config.json") {
-					t.Errorf("Expected path containing 'config.json', got: %s", result)
-				}
-			},
-		},
-		{
-			name:         "returns empty string when no config found",
-			providedPath: "",
-			setupFunc: func(t *testing.T) func() {
-				tmpDir := t.TempDir()
-				origWd, _ := os.Getwd()
-				os.Chdir(tmpDir)
-
-				return func() {
-					os.Chdir(origWd)
-				}
-			},
-			validateFunc: func(t *testing.T, result string) {
-				if result != "" {
-					t.Errorf("Expected empty string when no config found, got: %s", result)
+				if result != "/data/config.json" {
+					t.Errorf("Expected path '/data/config.json', got: %s", result)
 				}
 			},
 		},
@@ -1142,9 +1095,6 @@ func TestGetConfigPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cleanup := tc.setupFunc(t)
-			defer cleanup()
-
 			result := getConfigPath(tc.providedPath)
 			tc.validateFunc(t, result)
 		})

--- a/plans/data-config-json.md
+++ b/plans/data-config-json.md
@@ -1,0 +1,260 @@
+# Simplify Config Path to /data/config.json Only
+
+## Overview
+
+**Problem:** Current implementation has fallback logic trying `/data/config.json` then `./config.json`. This adds complexity for local development but container deployments always use `/data/`. Users outside containers can use `-c` flag for custom paths.
+
+**Approach:** Remove `./config.json` fallback from `loadConfig` and `getConfigPath` functions. Default path is `/data/config.json` only. Explicit `-c`/`--config` flag behavior unchanged.
+
+## Decisions
+
+| ID | Decision | Reasoning |
+|----|----------|-----------|
+| DL-001 | Remove ./config.json fallback, use only /data/config.json as default | Container deployments use /data/ mount point -> ./config.json fallback adds complexity for non-container use -> Users outside containers can use -c flag -> Simplifies logic and reduces cognitive load |
+| DL-002 | Keep getConfigPath function synchronized with loadConfig | getConfigPath determines which file to watch for hot-reload -> Must match loadConfig fallback logic exactly -> Removing ./config.json fallback from both maintains consistency |
+
+## Rejected Alternatives
+
+| ID | Alternative | Reason Rejected |
+|----|-------------|-----------------|
+| RA-001 | Add constant for default path /data/config.json | Overkill for single usage - the path is only referenced in two functions and adding a constant adds indirection without clarity benefit |
+| RA-002 | Keep fallback but log deprecation warning | Adds complexity for transitional period that is not needed - this is an internal tool with controlled deployments |
+
+## Constraints
+
+- MUST: Keep -c and --config CLI flags working exactly as before
+- MUST: Default path is /data/config.json only (no fallback to ./config.json)
+- MUST: Maintain no-config-at-startup behavior (nil config on missing file)
+- MUST-NOT: Change behavior when explicit path provided via -c/--config
+
+## Invariants
+
+- `ConfigManager.GetConfig()` returns nil when no config loaded (no-config-at-startup)
+- Missing config file returns nil, not error (graceful handling)
+- Hot-reload polling continues to work when config appears
+
+## Tradeoffs
+
+- Chose simplicity over flexibility: single default path reduces cognitive load
+- Non-container users must use `-c` flag for custom paths (acceptable tradeoff for container-first design)
+
+---
+
+## Milestone M-001: Simplify config path fallback logic
+
+### Files
+
+- `main.go`
+- `main_test.go`
+
+### Requirements
+
+1. Default config path is `/data/config.json` only (no `./config.json` fallback)
+2. `-c` and `--config` CLI flags continue to work exactly as before
+3. No-config-at-startup behavior preserved (nil config on missing file)
+
+### Acceptance Criteria
+
+- **AC-001:** `loadConfig("")` tries only /data/config.json, not ./config.json
+- **AC-002:** `getConfigPath("")` returns "/data/config.json" without checking file existence
+- **AC-003:** `loadConfig("/custom/path")` loads from explicit path unchanged
+- **AC-004:** All existing tests pass after changes
+
+---
+
+## Code Changes
+
+### CC-M-001-001: loadConfig - Remove ./config.json fallback
+
+**File:** `main.go`
+**Function:** `loadConfig`
+**Intent:** Remove `filepath.Join(wd, "config.json")` from `defaultPaths` slice. Only try `/data/config.json` when no explicit path provided. Update log message to reflect single search location.
+
+```diff
+--- a/main.go
++++ b/main.go
+@@ -819,30 +819,18 @@ func loadConfig(providedPath string) (*Config, error) {
+ 		return &cfg, nil
+ 	}
+
+-	// Otherwise, try default locations in priority order
+-	wd, err := os.Getwd()
+-	if err != nil {
+-		return nil, fmt.Errorf("failed to get working directory: %w", err)
+-	}
+-
+-	defaultPaths := []string{
+-		"/data/config.json",
+-		filepath.Join(wd, "config.json"),
+-	}
+-
+-	var errors []string
+-	for _, path := range defaultPaths {
+-		log.Printf("Attempting to load config from: %s", path)
+-
+-		data, err := os.ReadFile(path)
+-		if err != nil {
+-			errors = append(errors, fmt.Sprintf("  %s: %v", path, err))
+-			continue
+-		}
++	// Default path is /data/config.json only
++	defaultPath := "/data/config.json"
++	log.Printf("Attempting to load config from: %s", defaultPath)
+
+-		var cfg Config
+-		if err := json.Unmarshal(data, &cfg); err != nil {
+-			return nil, fmt.Errorf("failed to parse config from %s: %w", path, err)
+-		}
++	data, err := os.ReadFile(defaultPath)
++	if err != nil {
++		if os.IsNotExist(err) {
++			log.Printf("Config file not found at %s, starting without config", defaultPath)
++			return nil, nil
++		}
++		return nil, fmt.Errorf("failed to read config from %s: %w", defaultPath, err)
++	}
+
+-		log.Printf("Successfully loaded config from: %s", path)
+-		return &cfg, nil
++	var cfg Config
++	if err := json.Unmarshal(data, &cfg); err != nil {
++		return nil, fmt.Errorf("failed to parse config from %s: %w", defaultPath, err)
+ 	}
+
+-	// No config file found in any default location
+-	log.Printf("Config file not found at any default location. Starting without config.")
+-	log.Printf("Searched locations: /data/config.json, ./config.json")
++	log.Printf("Successfully loaded config from: %s", defaultPath)
++	return &cfg, nil
+-	log.Printf("Waiting for config to be created or provided via API...")
+-	return nil, nil
+ }
+```
+
+### CC-M-001-002: getConfigPath - Simplify to return /data/config.json directly
+
+**File:** `main.go`
+**Function:** `getConfigPath`
+**Intent:** Remove `filepath.Join(wd, "config.json")` from `defaultPaths` slice. Return `/data/config.json` directly when no explicit path provided (no stat check needed since loadConfig handles missing file gracefully).
+
+```diff
+--- a/main.go
++++ b/main.go
+@@ -856,32 +856,11 @@ func loadConfig(providedPath string) (*Config, error) {
+ // getConfigPath determines the actual config file path that loadConfig uses
+ // Matches loadConfig's fallback logic exactly: provided path -> /data/config.json -> ./config.json
+ func getConfigPath(providedPath string) string {
+ 	// If explicitly provided, return that path (matches loadConfig's provided-path mode)
+ 	if providedPath != "" {
+ 		return providedPath
+ 	}
+
+-	// Otherwise, try default locations in same priority order as loadConfig's fallback mode
+-	wd, err := os.Getwd()
+-	if err != nil {
+-		// If we can't get working directory, config load fails
+-		// Return empty string to signal error condition
+-		return ""
+-	}
+-
+-	defaultPaths := []string{
+-		"/data/config.json",
+-		filepath.Join(wd, "config.json"),
+-	}
+-
+-	// Return first existing path (matches loadConfig's fallback priority order)
+-	for _, path := range defaultPaths {
+-		if _, err := os.Stat(path); err == nil {
+-			return path
+-		}
+-	}
+-
+-	// No config file found - this matches loadConfig's error return when all paths fail
+-	// Empty string signals that no valid config path exists
+-	return ""
++	// Default path is /data/config.json only (matches loadConfig behavior)
++	return "/data/config.json"
+ }
+```
+
+### CC-M-001-003: TestGetConfigPath - Update test expectations
+
+**File:** `main_test.go`
+**Function:** `TestGetConfigPath`
+**Intent:** Update test cases to reflect new behavior: remove test for ./config.json fallback, update expected paths to /data/config.json only.
+
+```diff
+--- a/main_test.go
++++ b/main_test.go
+@@ -1083,68 +1083,28 @@ func TestGetConfigPath(t *testing.T) {
+ 	testCases := []struct {
+ 		name         string
+ 		providedPath string
+ 		setupFunc    func(t *testing.T) func()
+ 		validateFunc func(t *testing.T, result string)
+ 	}{
+ 		{
+ 			name:         "explicit path is returned",
+ 			providedPath: "/custom/config.json",
+ 			setupFunc:    func(t *testing.T) func() { return func() {} },
+ 			validateFunc: func(t *testing.T, result string) {
+ 				if result != "/custom/config.json" {
+ 					t.Errorf("Expected path '/custom/config.json', got: %s", result)
+ 				}
+ 			},
+ 		},
+ 		{
+-			name:         "uses ./config.json when /data/config.json doesn't exist",
++			name:         "returns /data/config.json when no path provided",
+ 			providedPath: "",
+ 			setupFunc: func(t *testing.T) func() {
+-				tmpDir := t.TempDir()
+-				configPath := filepath.Join(tmpDir, "config.json")
+-				os.WriteFile(configPath, []byte("{}"), 0644)
+-
+-				origWd, _ := os.Getwd()
+-				os.Chdir(tmpDir)
+-
+-				return func() {
+-					os.Chdir(origWd)
+-				}
++				return func() {}
+ 			},
+ 			validateFunc: func(t *testing.T, result string) {
+-				// Should return the working directory config.json
+-				if !strings.Contains(result, "config.json") {
+-					t.Errorf("Expected path containing 'config.json', got: %s", result)
++				if result != "/data/config.json" {
++					t.Errorf("Expected '/data/config.json', got: %s", result)
+ 				}
+ 			},
+ 		},
+-		{
+-			name:         "returns empty string when no config found",
+-			providedPath: "",
+-			setupFunc: func(t *testing.T) func() {
+-				tmpDir := t.TempDir()
+-				origWd, _ := os.Getwd()
+-				os.Chdir(tmpDir)
+-
+-				return func() {
+-					os.Chdir(origWd)
+-				}
+-			},
+-			validateFunc: func(t *testing.T, result string) {
+-				if result != "" {
+-					t.Errorf("Expected empty string when no config found, got: %s", result)
+-				}
+-			},
+-		},
+ 	}
+```
+
+---
+
+## Implementation Notes
+
+1. **loadConfig()** now has single default path - no loop needed
+2. **getConfigPath()** returns hardcoded path - no stat check needed since loadConfig handles missing file gracefully
+3. **No-config-at-startup** behavior preserved: missing /data/config.json returns nil config, not error
+4. **Hot-reload** continues to work: ConfigManager polls /data/config.json mtime


### PR DESCRIPTION
## Summary
- Remove `./config.json` fallback from `loadConfig` and `getConfigPath` functions
- Default config path is now `/data/config.json` only
- Container deployments use `/data/` mount point; non-container users can use `-c` flag for custom paths
- Simplified `loadConfig` from 97 to 39 lines, `getConfigPath` from 26 to 6 lines

## Test plan
- [x] All existing tests pass (`go test -v ./...`)
- [x] `loadConfig("")` tries only `/data/config.json`
- [x] `getConfigPath("")` returns `/data/config.json`
- [x] Explicit `-c`/`--config` flag behavior unchanged
- [x] No-config-at-startup behavior preserved (nil config on missing file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified config loading to use a single default path at /data/config.json and removed the ./config.json fallback. The -c/--config flag and no-config-at-startup behavior remain unchanged.

- **Refactors**
  - Updated loadConfig and getConfigPath to use /data/config.json when no path is provided.
  - Simplified tests to reflect the single-path behavior.
  - Adjusted docs to clarify the container-first default.

- **Migration**
  - Local development: pass -c /path/to/config.json or place your config at /data/config.json.
  - Container deployments: no changes needed.

<sup>Written for commit 8d9ab8791353cd56fbfacbe07615edf3cf262a36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

