### PR TITLE
fix(admin): refresh UI after config validation

### DIFF
--- a/api/web/admin/app.js
+++ b/api/web/admin/app.js
@@ -319,6 +319,8 @@ const App = {
         }
     },
 
+    // Refreshes config from server after validation to show current server state.
+    // Matches refresh pattern used in saveConfig and handleFileSelect. (ref: DL-001)
     // Validate config via API
     async validateConfig() {
         this.collectFormChanges();
@@ -327,6 +329,7 @@ const App = {
         // 400 = JSON syntax error
         if (response.ok || response.status === 501) {
             this.showMessage('JSON syntax is valid', 'success');
+            await this.loadConfig(); // Refresh from server
         } else {
             this.showMessage('Validation failed: ' + response.error, 'error');
         }

--- a/api/web/admin/app.js
+++ b/api/web/admin/app.js
@@ -27,6 +27,11 @@ const App = {
             this.handleLogout();
         });
 
+        // Login again button (on logged out screen)
+        document.getElementById('login-again-btn').addEventListener('click', () => {
+            this.showLoginScreen();
+        });
+
         // Add server button
         document.getElementById('add-server-btn').addEventListener('click', () => {
             this.addServer();
@@ -105,12 +110,20 @@ const App = {
     // Handle logout
     handleLogout() {
         window.Auth.logout();
-        this.showLoginScreen();
+        this.showLoggedOutScreen();
     },
 
-    // Show login screen
+    // Show logged out screen (after explicit logout)
+    showLoggedOutScreen() {
+        document.getElementById('login-screen').classList.add('hidden');
+        document.getElementById('logged-out-screen').classList.remove('hidden');
+        document.getElementById('config-screen').classList.add('hidden');
+    },
+
+    // Show login screen (for initial auth or "log in again")
     showLoginScreen() {
         document.getElementById('login-screen').classList.remove('hidden');
+        document.getElementById('logged-out-screen').classList.add('hidden');
         document.getElementById('config-screen').classList.add('hidden');
         document.getElementById('token-input').value = '';
     },
@@ -118,6 +131,7 @@ const App = {
     // Show config screen and load data
     async showConfigScreen() {
         document.getElementById('login-screen').classList.add('hidden');
+        document.getElementById('logged-out-screen').classList.add('hidden');
         document.getElementById('config-screen').classList.remove('hidden');
         await this.loadConfig();
     },

--- a/api/web/admin/app.js
+++ b/api/web/admin/app.js
@@ -319,9 +319,7 @@ const App = {
         }
     },
 
-    // Refreshes config from server after validation to show current server state.
-    // Matches refresh pattern used in saveConfig and handleFileSelect. (ref: DL-001)
-    // Validate config via API
+    // Validate config via API (syntax check only, does not persist changes)
     async validateConfig() {
         this.collectFormChanges();
         const response = await window.APIClient.post('/config/validate', this.buildConfigPayload());
@@ -329,7 +327,6 @@ const App = {
         // 400 = JSON syntax error
         if (response.ok || response.status === 501) {
             this.showMessage('JSON syntax is valid', 'success');
-            await this.loadConfig(); // Refresh from server
         } else {
             this.showMessage('Validation failed: ' + response.error, 'error');
         }

--- a/api/web/admin/index.html
+++ b/api/web/admin/index.html
@@ -1,5 +1,5 @@
 <!-- Admin UI: Single-page app for AC Bot configuration (ref: DL-002). -->
-<!-- Two-screen design: login form, then config editor. -->
+<!-- Three-screen design: login form, logged out confirmation, config editor. -->
 <!-- Security: password input type prevents token visibility. -->
 <!-- Script load order: auth.js -> api.js -> app.js (dependency chain). -->
 <!DOCTYPE html>
@@ -13,7 +13,7 @@
 <body>
     <div id="app">
         <!-- Login Screen -->
-        <section id="login-screen" class="screen">
+        <section id="login-screen" class="screen hidden">
             <h1>AC Bot Configuration</h1>
             <form id="login-form">
                 <div class="form-group">
@@ -26,6 +26,13 @@
                 <button type="submit" id="login-btn">Login</button>
                 <p id="login-error" class="error-message hidden"></p>
             </form>
+        </section>
+
+        <!-- Logged Out Screen -->
+        <section id="logged-out-screen" class="screen hidden">
+            <h1>Logged Out</h1>
+            <p>Your session has ended.</p>
+            <button id="login-again-btn">Log in again</button>
         </section>
 
         <!-- Main Config Editor -->

--- a/main.go
+++ b/main.go
@@ -348,6 +348,14 @@ func (cm *ConfigManager) WriteConfig(newConfig *Config) error {
 		return fmt.Errorf("failed to update config mod time: %w", err)
 	}
 
+	// Atomically swap in-memory config and update mod time
+	// This ensures GetConfig returns the new config immediately after write
+	cm.config.Store(newConfig)
+	cm.lastModTime, err = cm.getLastModTime()
+	if err != nil {
+		return fmt.Errorf("failed to get config mod time: %w", err)
+	}
+
 	return nil
 }
 
@@ -396,6 +404,14 @@ func (cm *ConfigManager) UpdateConfig(partial map[string]interface{}) error {
 	// Update mod time
 	if err := cm.touchConfigFile(); err != nil {
 		log.Printf("Warning: failed to update config mod time: %v", err)
+	}
+
+	// Atomically swap in-memory config and update mod time
+	// This ensures GetConfig returns the merged config immediately after update
+	cm.config.Store(merged)
+	cm.lastModTime, err = cm.getLastModTime()
+	if err != nil {
+		log.Printf("Warning: failed to get config mod time: %v", err)
 	}
 
 	return nil

--- a/plans/auto-refresh.md
+++ b/plans/auto-refresh.md
@@ -1,0 +1,100 @@
+# Auto-Refresh Admin GUI
+
+## Overview
+
+`validateConfig()` does not refresh UI after successful validation, unlike `saveConfig()` and `handleFileSelect()` which both call `loadConfig()` to show current server state.
+
+**Approach**: Add `await this.loadConfig()` call after successful validateConfig response, following established pattern.
+
+**Note**: Upload already calls `loadConfig()` after success (app.js:372), so this plan only addresses the validate button.
+
+## Planning Context
+
+### Decision Log
+
+| ID | Decision | Reasoning Chain |
+|---|---|---|
+| DL-001 | Add loadConfig call after validateConfig success | saveConfig and handleFileSelect already call loadConfig after success -> validateConfig should follow same pattern for consistency -> user sees current server state after validate |
+
+### Constraints
+
+- MUST: Maintain vanilla JS approach (no framework)
+- MUST: Preserve XSS prevention patterns (textContent, no innerHTML for user content)
+- MUST: Handle async operations properly (await loadConfig after actions)
+
+### Known Risks
+
+- **loadConfig failure after successful validate leaves UI with stale config state**: User sees validation success but UI shows old data. Mitigation: Existing error handling in `loadConfig()` will show error message to user.
+
+## Invisible Knowledge
+
+### System
+
+Admin GUI is vanilla JS SPA; `loadConfig()` fetches from `GET /api/config`; validate endpoint only checks JSON syntax.
+
+### Invariants
+
+- `loadConfig()` always replaces `this.config` AND calls `renderConfig()` to update UI (app.js:126-134)
+- `validateConfig()` sends current form state to `/config/validate` endpoint for JSON syntax check only
+- Upload writes config via `WriteConfigAny` and returns updated config
+
+### Tradeoffs
+
+- Validate endpoint returns 501 with `json_syntax` info but does NOT return config (handlers.go:180-186) - this is why `loadConfig()` call is needed after validate (unlike upload which returns updated config)
+
+## Milestones
+
+### Milestone 1: Auto-refresh after validate
+
+**Files**: api/web/admin/app.js
+
+**Acceptance Criteria**:
+
+- After pressing validate button with valid JSON, UI refreshes with current server config
+- Pattern matches existing saveConfig and handleFileSelect implementations
+
+#### Code Changes
+
+**CC-M-001-001** (api/web/admin/app.js) - implements CI-M-001-001
+
+**Code:**
+
+```diff
+@@ -322,12 +322,13 @@ const App = {
+     // Validate config via API
+     async validateConfig() {
+         this.collectFormChanges();
+         const response = await window.APIClient.post('/config/validate', this.buildConfigPayload());
+         // 501 = JSON syntax valid, full validation requires PUT
+         // 400 = JSON syntax error
+         if (response.ok || response.status === 501) {
+             this.showMessage('JSON syntax is valid', 'success');
++            await this.loadConfig(); // Refresh from server
+         } else {
+             this.showMessage('Validation failed: ' + response.error, 'error');
+         }
+     },
+```
+
+**Documentation:**
+
+```diff
+--- a/api/web/admin/app.js
++++ b/api/web/admin/app.js
+@@ -320,6 +320,8 @@ const App = {
+     },
+
++    // Refreshes config from server after validation to show current server state.
++    // Matches refresh pattern used in saveConfig and handleFileSelect. (ref: DL-001)
+     // Validate config via API
+     async validateConfig() {
+
+```
+
+## Testing
+
+Manual browser testing:
+1. Load admin UI
+2. Make config changes
+3. Press validate button
+4. Verify UI shows current server state after validation succeeds


### PR DESCRIPTION
## Summary
- Add `loadConfig()` call after successful config validation to refresh UI with current server state
- Matches the refresh pattern already used in `saveConfig()` and `handleFileSelect()` for consistent UX

## Test plan
- [ ] Load admin UI
- [ ] Make config changes
- [ ] Press validate button
- [ ] Verify UI shows current server state after validation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-refresh after config validation to preserve unsaved edits and clarifies it's a syntax-only check. Atomically swaps the in-memory config on save/update for immediate UI refresh and adds a simple "Logged Out" screen with a "Log in again" button.

<sup>Written for commit b25aa439462658a933220b8300f6036974157e4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

