### PR TITLE
fix: security updates and CI workflow fixes

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  # Only enable packages: write for build-and-push job
 
 # Prevent concurrent runs on the same branch
 concurrency:
@@ -92,6 +91,8 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     needs: [govulncheck, image-test]
+    permissions:
+      packages: write
     steps:
       - name: Checkout repository
         # actions/checkout@v4.0.0 (pinned SHA: 1e31de5234b9f8995739874a8ce0492dc87873e2)

--- a/.github/workflows/run-security-image-tests.yaml
+++ b/.github/workflows/run-security-image-tests.yaml
@@ -1,0 +1,133 @@
+name: Run security checks and image tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Only enable packages: write for build-and-push job
+
+# Prevent concurrent runs on the same branch
+concurrency:
+  group: sec-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secretscan:
+    name: Run truffleHog secrets scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # actions/checkout@v6.0.2 (pinned SHA: de0fac2e4500dabe0009e67214ff5f5447ce83dd)
+        # NOTE: credentials may persist in artifacts, review usage
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run truffleHog secrets scan
+        # trufflesecurity/trufflehog@v3.93.7 (pinned SHA: c3e599b7163e8198a55467f3133db0e7b2a492cb)
+        uses: trufflesecurity/trufflehog@c3e599b7163e8198a55467f3133db0e7b2a492cb
+        with:
+          extra_args: --results=verified,unknown
+
+  govulncheck:
+    name: Run govulncheck (Go dependency vulnerability scan)
+    runs-on: ubuntu-latest
+    needs: secretscan
+    steps:
+      - name: Checkout repository
+        # actions/checkout@v6.0.2 (pinned SHA: de0fac2e4500dabe0009e67214ff5f5447ce83dd)
+        # NOTE: credentials may persist in artifacts, review usage
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run govulncheck (Go dependency vulnerability scan)
+        # golang/govulncheck-action@v1.0.4 (pinned SHA: b625fbe08f3bccbe446d94fbf87fcc875a4f50ee)
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+        with:
+          go-version-input: 1.26.1
+          go-package: ./...
+
+  image-test:
+    name: Run image tests
+    runs-on: ubuntu-latest
+    needs: govulncheck
+    steps:
+      - name: Checkout repository
+        # actions/checkout@v6.0.2 (pinned SHA: de0fac2e4500dabe0009e67214ff5f5447ce83dd)
+        # NOTE: credentials may persist in artifacts, review usage
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        # docker/setup-buildx-action@v4.0.0 (pinned SHA: 4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd)
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - name: Build image (local cache only)
+        id: build-local
+        # docker/build-push-action@v7.0.0 (pinned SHA: d08e5c354a6adb9ed34480a06d141179aa583294)
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ac-discordbot:test
+      - name: Run container and check UID/GID
+        run: |
+          docker run --rm --entrypoint id ac-discordbot:test -u
+          uid=$(docker run --rm --entrypoint id ac-discordbot:test -u)
+          gid=$(docker run --rm --entrypoint id ac-discordbot:test -g)
+          if [ "$uid" != "1001" ] || [ "$gid" != "1001" ]; then
+            echo "FATAL: Container runs as $uid:$gid, expected 1001:1001" >&2
+            exit 1
+          fi
+          echo "PASS: Container runs as non-root $uid:$gid"
+
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    needs: [govulncheck, image-test]
+    steps:
+      - name: Checkout repository
+        # actions/checkout@v4.0.0 (pinned SHA: 1e31de5234b9f8995739874a8ce0492dc87873e2)
+        # NOTE: credentials may persist in artifacts, review usage
+        uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        # docker/setup-buildx-action@v4.0.0 (pinned SHA: 4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd)
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to GitHub Container Registry
+        # docker/login-action@v4.0.0 (pinned SHA: b45d80f862d83dbcd57f89517bcf500b2ab88fb2)
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata
+        id: meta
+        # docker/metadata-action@v6.0.0 (pinned SHA: 030e881283bb7a6894de51c315a6bfe6a94e05cf)
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ac-discordbot
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        # docker/build-push-action@v7.0.0 (pinned SHA: d08e5c354a6adb9ed34480a06d141179aa583294)
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/run-security-image-tests.yaml
+++ b/.github/workflows/run-security-image-tests.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  # Only enable packages: write for build-and-push job
 
 # Prevent concurrent runs on the same branch
 concurrency:
@@ -86,8 +85,8 @@ jobs:
           fi
           echo "PASS: Container runs as non-root $uid:$gid"
 
-  build-and-push:
-    name: Build and push Docker image
+  build:
+    name: Build Docker image
     runs-on: ubuntu-latest
     needs: [govulncheck, image-test]
     steps:
@@ -102,14 +101,6 @@ jobs:
         # docker/setup-buildx-action@v4.0.0 (pinned SHA: 4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd)
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
-      - name: Log in to GitHub Container Registry
-        # docker/login-action@v4.0.0 (pinned SHA: b45d80f862d83dbcd57f89517bcf500b2ab88fb2)
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Extract metadata
         id: meta
         # docker/metadata-action@v6.0.0 (pinned SHA: 030e881283bb7a6894de51c315a6bfe6a94e05cf)
@@ -121,7 +112,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         # docker/build-push-action@v7.0.0 (pinned SHA: d08e5c354a6adb9ed34480a06d141179aa583294)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:

--- a/Containerfile
+++ b/Containerfile
@@ -36,8 +36,4 @@ USER 1001
 EXPOSE 3001
 EXPOSE 8080
 
-# Set environment variables (replace at runtime)
-ENV DISCORD_TOKEN=""
-ENV CHANNEL_ID=""
-
 CMD ["./bot"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM docker.io/library/golang:1.26.0-alpine AS builder
+FROM docker.io/library/golang:1.26.1-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bombom/absa-ac
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.26.0 to 1.26.1 for security fixes
- Add `packages: write` permission to `build-and-push` job for GHCR push access
- Remove unnecessary GHCR login from `run-security-image-tests` workflow (it has `push: false`)
- Remove sensitive ENV placeholders (`DISCORD_TOKEN`, `CHANNEL_ID`) from Containerfile

## Test plan
- [ ] Verify `docker-publish` workflow can push to GHCR on next tag release
- [ ] Verify `run-security-image-tests` workflow builds successfully without login step
- [ ] Confirm no Docker security warnings for Containerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Go to 1.26.1 and harden Docker/CI. Adds a build-only `run-security-image-tests` workflow, fixes GHCR push permissions, and removes placeholder envs from the image.

- **Dependencies**
  - Upgrade `golang` to 1.26.1 in Containerfile and `go.mod` (patches GO-2026-4599, -4600, -4601, -4602).

- **Bug Fixes**
  - CI: grant `packages: write` to `build-and-push` in `docker-publish`.
  - Security tests: rename job to `build`, remove GHCR login and push; build-only.
  - Container: remove `DISCORD_TOKEN` and `CHANNEL_ID` placeholders.

<sup>Written for commit 75bfa032b1d29a90b744f80de03f1bc2bafdcbb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

